### PR TITLE
Report error properly when `OPENAI_API_KEY` is not set

### DIFF
--- a/src/chatdbg/chatdbg_why.py
+++ b/src/chatdbg/chatdbg_why.py
@@ -112,7 +112,7 @@ async def why(self, arg):
     text = ""
     try:
         completion = await openai_async.chat_complete(
-            openai.api_key,
+            openai.api_key or "",
             timeout=30,
             payload={
                 "model": "gpt-3.5-turbo",


### PR DESCRIPTION
Fixes https://github.com/plasma-umass/ChatDBG/issues/2.

Previously, running `why` when `OPENAI_API_KEY` was not set led to an obscure message:
```
(ChatDBG Pdb) why
EXCEPTION 'choices'
```

This happened because `openai_async.chat_complete` does not raise `openai.error.AuthenticationError` when `openai.api_key` is `None`. To handle it, `None` is now replaced with an empty string literal.