### PR TITLE
Add sanity check CI

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -1,0 +1,26 @@
+name: Sanity
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  sanity:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Update pip
+        run: python3 -m pip install --upgrade pip
+
+      - name: Install
+        run: python3 -m pip install .
+
+      - name: Install in editable mode
+        run: python3 -m pip install -e .
+
+      - name: Check version
+        run: python3 -m chatdbg

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -22,5 +22,5 @@ jobs:
       - name: Install in editable mode
         run: python3 -m pip install -e .
 
-      - name: Check version
-        run: python3 -m chatdbg
+      - name: Check help message
+        run: python3 -m chatdbg --help

--- a/src/chatdbg/chatdbg.py
+++ b/src/chatdbg/chatdbg.py
@@ -52,13 +52,13 @@ def main():
 
     opts, args = getopt.getopt(sys.argv[1:], "mhc:", ["help", "command="])
 
-    if not args:
-        print(_usage)
-        sys.exit(2)
-
     if any(opt in ["-h", "--help"] for opt, optarg in opts):
         print(_usage)
         sys.exit()
+
+    if not args:
+        print(_usage)
+        sys.exit(2)
 
     commands = [optarg for opt, optarg in opts if opt in ["-c", "--command"]]
 


### PR DESCRIPTION
As of right now, this should fail (#16). This check just makes sure `pip install` works and we're able to just print ChatDBG's version. I added a similar check in [CWhy](https://github.com/plasma-umass/cwhy) earlier.