### PR TITLE
Fix #21, remove dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 authors = [
   { name="Emery Berger", email="emery.berger@gmail.com" },
 ]
-dependencies = ["openai>=0.27.0", "openai_async>=0.0.3", "aiohttp>=3.8.3"]
+dependencies = ["openai>=0.27.0"]
 description = "ChatDBG."
 readme = "README.md"
 requires-python = ">=3.7"

--- a/src/chatdbg/chatdbg_gdb.py
+++ b/src/chatdbg/chatdbg_gdb.py
@@ -1,14 +1,13 @@
 # Add 'source <path to chatdbg>/chatdbg_gdb.py' to ~/.gdbinit
 
 import asyncio
-import gdb
 import os
-import openai
-import openai_async
+import pathlib
 import sys
 import textwrap
 
-import pathlib
+import gdb
+import openai
 
 the_path = pathlib.Path(__file__).parent.resolve()
 

--- a/src/chatdbg/chatdbg_lldb.py
+++ b/src/chatdbg/chatdbg_lldb.py
@@ -267,4 +267,5 @@ def why(
 def why_prompt(
     debugger: lldb.SBDebugger, command: str, result: str, internal_dict: dict
 ) -> None:
+    """Output the prompt that `why` would generate (for debugging purposes only)."""
     why(debugger, command, result, internal_dict, really_run=False)

--- a/src/chatdbg/chatdbg_lldb.py
+++ b/src/chatdbg/chatdbg_lldb.py
@@ -1,11 +1,11 @@
 #!env python3
-import lldb
 import asyncio
 import os
+import pathlib
 import re
 import sys
 
-import pathlib
+import lldb
 
 the_path = pathlib.Path(__file__).parent.resolve()
 
@@ -14,9 +14,9 @@ rust_panic_log_filename = "panic_log.txt"
 
 sys.path.append(os.path.abspath(the_path))
 
-import chatdbg_utils
-
 from typing import Tuple, Union
+
+import chatdbg_utils
 
 
 def __lldb_init_module(debugger: lldb.SBDebugger, internal_dict: dict) -> None:

--- a/src/chatdbg/chatdbg_utils.py
+++ b/src/chatdbg/chatdbg_utils.py
@@ -129,7 +129,7 @@ async def explain(
             messages=[{"role": "user", "content": user_prompt}],
         )
         text = completion.choices[0].message.content
-        print(chatdbg_utils.word_wrap_except_code_blocks(text))
+        print(word_wrap_except_code_blocks(text))
     except openai.error.AuthenticationError:
         print(
             "You need a valid OpenAI key to use ChatDBG. You can get a key here: https://openai.com/api/"

--- a/src/chatdbg/chatdbg_utils.py
+++ b/src/chatdbg/chatdbg_utils.py
@@ -69,55 +69,8 @@ def word_wrap_except_code_blocks(text: str) -> str:
     return wrapped_text
 
 
-def word_wrap_except_code_blocks_previous(text: str) -> str:
-    """Wraps text except for code blocks.
-
-    Splits the text into paragraphs and wraps each paragraph,
-    except for paragraphs that are inside of code blocks denoted
-    by ` ``` `. Returns the updated text.
-
-    Args:
-        text: The text to wrap.
-
-    Returns:
-        The wrapped text.
-    """
-    # Split text into paragraphs
-    paragraphs = text.split("\n\n")
-    wrapped_paragraphs = []
-    # Check if currently in a code block.
-    in_code_block = False
-    # Loop through each paragraph and apply appropriate wrapping.
-    for paragraph in paragraphs:
-        # If this paragraph starts and ends with a code block, add it as is.
-        if paragraph.startswith("```") and paragraph.endswith("```"):
-            wrapped_paragraphs.append(paragraph)
-            continue
-        # If this is the beginning of a code block add it as is.
-        if paragraph.startswith("```"):
-            in_code_block = True
-            wrapped_paragraphs.append(paragraph)
-            continue
-        # If this is the end of a code block stop skipping text.
-        if paragraph.endswith("```"):
-            in_code_block = False
-            wrapped_paragraphs.append(paragraph)
-            continue
-        # If we are currently in a code block add the paragraph as is.
-        if in_code_block:
-            wrapped_paragraphs.append(paragraph)
-        else:
-            # Otherwise, apply text wrapping to the paragraph.
-            wrapped_paragraph = textwrap.fill(paragraph)
-            wrapped_paragraphs.append(wrapped_paragraph)
-    # Join all paragraphs into a single string
-    wrapped_text = "\n\n".join(wrapped_paragraphs)
-    return wrapped_text
-
-
 def read_lines_width() -> int:
     return 10
-
 
 def read_lines(file_path: str, start_line: int, end_line: int) -> str:
     """

--- a/src/chatdbg/chatdbg_utils.py
+++ b/src/chatdbg/chatdbg_utils.py
@@ -1,8 +1,8 @@
-import openai
-import openai_async
 import os
 import sys
 import textwrap
+
+import openai
 
 
 def get_model() -> str:
@@ -165,39 +165,20 @@ async def explain(
         print(user_prompt)
         return
 
-    if not "OPENAI_API_KEY" in os.environ:
-        print(
-            "You need a valid OpenAI key to use ChatDBG. You can get a key here: https://openai.com/api/"
-        )
-        print("Set the environment variable OPENAI_API_KEY to your key value.")
-        return
-
     model = get_model()
     if not model:
         return
 
     try:
-        completion = await openai_async.chat_complete(
-            openai.api_key,
-            timeout=30,
-            payload={
-                "model": f"{model}",
-                "messages": [{"role": "user", "content": user_prompt}],
-            },
+        completion = openai.ChatCompletion.create(
+            model=model,
+            request_timeout=30,
+            messages=[{"role": "user", "content": user_prompt}],
         )
-        json_payload = completion.json()
-        text = json_payload["choices"][0]["message"]["content"]
-    except (openai.error.AuthenticationError, httpx.LocalProtocolError, KeyError):
-        # Something went wrong.
-        print()
+        text = completion.choices[0].message.content
+        print(chatdbg_utils.word_wrap_except_code_blocks(text))
+    except openai.error.AuthenticationError:
         print(
             "You need a valid OpenAI key to use ChatDBG. You can get a key here: https://openai.com/api/"
         )
         print("Set the environment variable OPENAI_API_KEY to your key value.")
-        import sys
-
-        sys.exit(1)
-    except Exception as e:
-        print(f"EXCEPTION {e}, {type(e)}")
-        pass
-    print(word_wrap_except_code_blocks(text))


### PR DESCRIPTION
This should provide better errors by just letting exceptions fall through, I'm not able to test this at the moment so probably some errors in there, but will do later today or tomorrow and adjust.

The `openai-async` package is not updated, and the `openai` official package has async requests built-in anyway. But in this case, since were waiting for an answer before displaying anyway, we can make this synchronous.