### PR TITLE
Ignore any warnings LiteLLM might emit on import

### DIFF
--- a/src/chatdbg/assistant/assistant.py
+++ b/src/chatdbg/assistant/assistant.py
@@ -4,7 +4,12 @@ import textwrap
 import time
 import pprint
 
-import litellm
+import warnings
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    import litellm
+
 import openai
 
 from ..util.trim import sandwich_tokens, trim_messages

--- a/src/chatdbg/util/trim.py
+++ b/src/chatdbg/util/trim.py
@@ -1,6 +1,10 @@
 
 import copy
-import litellm
+import warnings
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    import litellm
 
 def sandwich_tokens(
     text: str, model: str, max_tokens: int = 1024, top_proportion: float = 0.5


### PR DESCRIPTION
If you run ChatDBG with a recent version of LiteLLM, you'll get a few warnings:

```
/home/vscode/.local/lib/python3.10/site-packages/pydantic/_internal/_fields.py:149: UserWarning: Field "model_list" has conflict with protected namespace "model_".

You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ()`.
  warnings.warn(
/home/vscode/.local/lib/python3.10/site-packages/pydantic/_internal/_fields.py:149: UserWarning: Field "model_name" has conflict with protected namespace "model_".

You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ()`.
  warnings.warn(
/home/vscode/.local/lib/python3.10/site-packages/pydantic/_internal/_fields.py:149: UserWarning: Field "model_group_alias" has conflict with protected namespace "model_".

You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ()`.
  warnings.warn(
/home/vscode/.local/lib/python3.10/site-packages/pydantic/_internal/_fields.py:149: UserWarning: Field "model_info" has conflict with protected namespace "model_".

You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ()`.
  warnings.warn(
/home/vscode/.local/lib/python3.10/site-packages/pydantic/_internal/_fields.py:149: UserWarning: Field "model_id" has conflict with protected namespace "model_".

You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ()`.
  warnings.warn(
```

This has already been raised here: https://github.com/BerriAI/litellm/issues/2832.
In the meantime and/or until LiteLLM releases are a bit more stable, maybe we can just ignore warnings so ChatDBG users don't think it comes from us. An alternative solution would be to be more aggressive about pinning LiteLLM versions.