### PR TITLE
Add --unsafe mode, add barebone safe mode to LLDB/GDB.

### DIFF
--- a/src/chatdbg/chatdbg_gdb.py
+++ b/src/chatdbg/chatdbg_gdb.py
@@ -13,6 +13,7 @@ from chatdbg.native_util.stacks import (
     _SkippedFramesEntry,
 )
 from chatdbg.util.config import chatdbg_config
+from chatdbg.native_util.safety import command_is_safe
 
 # The file produced by the panic handler if the Rust program is using the chatdbg crate.
 RUST_PANIC_LOG_FILENAME = "panic_log.txt"
@@ -262,7 +263,7 @@ class GDBDialog(DBGDialog):
         """
         return None
 
-    def llm_debug(self, command: str) -> str:
+    def llm_debug(self, command: str):
         """
         {
             "name": "debug",
@@ -279,4 +280,6 @@ class GDBDialog(DBGDialog):
             }
         }
         """
+        if not chatdbg_config.unsafe and not command_is_safe(command):
+            return command, f"Command `{command}` is not allowed."
         return command, self._run_one_command(command)

--- a/src/chatdbg/chatdbg_lldb.py
+++ b/src/chatdbg/chatdbg_lldb.py
@@ -13,6 +13,7 @@ from chatdbg.native_util.stacks import (
     _SkippedFramesEntry,
 )
 from chatdbg.util.config import chatdbg_config
+from chatdbg.native_util.safety import command_is_safe
 
 # The file produced by the panic handler if the Rust program is using the chatdbg crate.
 RUST_PANIC_LOG_FILENAME = "panic_log.txt"
@@ -290,7 +291,7 @@ class LLDBDialog(DBGDialog):
         """
         return None
 
-    def llm_debug(self, command: str) -> str:
+    def llm_debug(self, command: str):
         """
         {
             "name": "debug",
@@ -307,4 +308,6 @@ class LLDBDialog(DBGDialog):
             }
         }
         """
+        if not chatdbg_config.unsafe and not command_is_safe(command):
+            return command, f"Command `{command}` is not allowed."
         return command, self._run_one_command(command)

--- a/src/chatdbg/chatdbg_pdb.py
+++ b/src/chatdbg/chatdbg_pdb.py
@@ -267,10 +267,10 @@ class ChatDBG(ChatDBGSuper):
             self.lastcmd = lastcmd
 
     def default(self, line):
-        if line[:1] == "!":
+        if line[0] == "!":
             super().default(line)
         else:
-            if line[:1] == ":":
+            if line[0] == ":":
                 line = line[1:].strip()
             self.do_chat(line)
 
@@ -284,6 +284,9 @@ class ChatDBG(ChatDBGSuper):
         """
         Sandbox for evaluating expressions from the LLM.
         """
+        if chatdbg_config.unsafe:
+            return super._getval(arg)
+        
         try:
             return sandbox_eval(arg, self.curframe.f_globals, self.curframe_locals)
         except NameError as e:

--- a/src/chatdbg/chatdbg_pdb.py
+++ b/src/chatdbg/chatdbg_pdb.py
@@ -284,11 +284,11 @@ class ChatDBG(ChatDBGSuper):
         """
         Sandbox for evaluating expressions from the LLM.
         """
-        if chatdbg_config.unsafe:
-            return super._getval(arg)
-        
         try:
-            return sandbox_eval(arg, self.curframe.f_globals, self.curframe_locals)
+            if chatdbg_config.unsafe:
+                return super._getval(arg)
+            else:   
+                return sandbox_eval(arg, self.curframe.f_globals, self.curframe_locals)
         except NameError as e:
             self.error(f"NameError: {e}")
             return None

--- a/src/chatdbg/chatdbg_pdb.py
+++ b/src/chatdbg/chatdbg_pdb.py
@@ -267,10 +267,10 @@ class ChatDBG(ChatDBGSuper):
             self.lastcmd = lastcmd
 
     def default(self, line):
-        if line[0] == "!":
+        if line[:1] == "!":
             super().default(line)
         else:
-            if line[0] == ":":
+            if line[:1] == ":":
                 line = line[1:].strip()
             self.do_chat(line)
 

--- a/src/chatdbg/native_util/safety.py
+++ b/src/chatdbg/native_util/safety.py
@@ -1,0 +1,32 @@
+import re
+
+
+# A very simple whitelist-based approach.
+# If ChatDBG wants to call other commands not listed here, they should be
+# evaluated and added if not possibly harmful.
+def command_is_safe(cmd: str) -> bool:
+    cmd = cmd.strip()
+    command_name = cmd.split()[0]
+
+    # Allowed unconditionally.
+    if command_name in [
+        "apropos",
+        "bt",
+        "down",
+        "frame",
+        "h",
+        "help",
+        "language",
+        "l",
+        "list",
+        "source",
+        "up",
+        "version",
+    ]:
+        return True
+
+    # Allowed conditionally.
+    if command_name in ["p", "print"]:
+        return re.fullmatch(r"[a-zA-Z0-9_ *]*", cmd) is not None
+
+    return False

--- a/src/chatdbg/util/config.py
+++ b/src/chatdbg/util/config.py
@@ -23,7 +23,7 @@ def _chatdbg_get_env(
     if type(default_value) == int:
         return int(v)
     elif type(default_value) == bool:
-        return v.lower() == "true"
+        return v.lower() == "true" or v.lower() == "1"
     else:
         return v
 
@@ -85,16 +85,21 @@ class ChatDBGConfig(Configurable):
 
     format = Unicode(
         _chatdbg_get_env("format", "md"),
-        help="The output format (text or md or md:simple or jupyter).",
+        help="The output format (text or md or md:simple or jupyter)",
     ).tag(config=True)
 
     instructions = Unicode(
         _chatdbg_get_env("instructions", ""),
-        help="The file for the initial instructions to the LLM, or '' for the default (possibly-model specific) version.",
+        help="The file for the initial instructions to the LLM, or '' for the default (possibly-model specific) version",
     ).tag(config=True)
 
     module_whitelist = Unicode(
         _chatdbg_get_env("module_whitelist", ""), help="The module whitelist file"
+    ).tag(config=True)
+
+    unsafe = Bool(
+        _chatdbg_get_env("unsafe", False),
+        help="Disable any protections against GPT running harmful code or commands",
     ).tag(config=True)
 
     _user_configurable = [
@@ -105,6 +110,7 @@ class ChatDBGConfig(Configurable):
         no_stream,
         format,
         module_whitelist,
+        unsafe,
     ]
 
     def _parser(self):


### PR DESCRIPTION

I had bigger ideas for this, but let's keep it simple for time constraints. I may change it in the future.

For now, a very restrictive safe mode: only a few no-side-effects functions allowed, plus print only allowing `[a-zA-Z0-9_ *]`.

Added the `--unsafe` flag for all 3 debuggers to disable any security.
