### PR TITLE
Added exit msgs

### DIFF
--- a/src/chatdbg/chatdbg_gdb.py
+++ b/src/chatdbg/chatdbg_gdb.py
@@ -40,7 +40,6 @@ def stop_handler(event):
 
 gdb.events.stop.connect(stop_handler)
 
-# Register the exit event handler
 gdb.events.exited.connect(print_exit_message)
 
 

--- a/src/chatdbg/chatdbg_gdb.py
+++ b/src/chatdbg/chatdbg_gdb.py
@@ -1,6 +1,6 @@
 import os
+import atexit
 from typing import List, Optional, Union
-
 
 import gdb
 
@@ -15,7 +15,6 @@ from chatdbg.native_util.stacks import (
 from chatdbg.util.config import chatdbg_config
 from chatdbg.native_util.safety import command_is_safe
 from chatdbg.util.exit_message import chatdbg_was_called, print_exit_message
-import atexit
 
 # The file produced by the panic handler if the Rust program is using the chatdbg crate.
 RUST_PANIC_LOG_FILENAME = "panic_log.txt"

--- a/src/chatdbg/chatdbg_gdb.py
+++ b/src/chatdbg/chatdbg_gdb.py
@@ -14,7 +14,8 @@ from chatdbg.native_util.stacks import (
 )
 from chatdbg.util.config import chatdbg_config
 from chatdbg.native_util.safety import command_is_safe
-from chatdbg.util.exit_message import print_exit_message
+from chatdbg.util.exit_message import chatdbg_was_called, print_exit_message
+import atexit
 
 # The file produced by the panic handler if the Rust program is using the chatdbg crate.
 RUST_PANIC_LOG_FILENAME = "panic_log.txt"
@@ -25,6 +26,8 @@ gdb.prompt_hook = lambda current_prompt: PROMPT
 
 
 last_error_type = ""
+
+atexit.register(print_exit_message)
 
 
 def stop_handler(event):
@@ -39,8 +42,6 @@ def stop_handler(event):
 
 
 gdb.events.stop.connect(stop_handler)
-
-gdb.events.exited.connect(print_exit_message)
 
 
 class Code(gdb.Command):
@@ -108,6 +109,7 @@ gdb.execute("alias chat = why")
 class GDBDialog(DBGDialog):
 
     def __init__(self, prompt) -> None:
+        chatdbg_was_called()
         super().__init__(prompt)
 
     def _message_is_a_bad_command_error(self, message):

--- a/src/chatdbg/chatdbg_gdb.py
+++ b/src/chatdbg/chatdbg_gdb.py
@@ -14,6 +14,7 @@ from chatdbg.native_util.stacks import (
 )
 from chatdbg.util.config import chatdbg_config
 from chatdbg.native_util.safety import command_is_safe
+from chatdbg.util.exit_message import print_exit_message
 
 # The file produced by the panic handler if the Rust program is using the chatdbg crate.
 RUST_PANIC_LOG_FILENAME = "panic_log.txt"
@@ -39,15 +40,8 @@ def stop_handler(event):
 
 gdb.events.stop.connect(stop_handler)
 
-
-def on_exit(event):
-    print(
-        f"Thank you for using ChatDBG!\nIf you've enjoyed your experience, feel free to share your success stories here: https://github.com/plasma-umass/ChatDBG/issues/53"
-    )
-
-
 # Register the exit event handler
-gdb.events.exited.connect(on_exit)
+gdb.events.exited.connect(print_exit_message)
 
 
 class Code(gdb.Command):

--- a/src/chatdbg/chatdbg_gdb.py
+++ b/src/chatdbg/chatdbg_gdb.py
@@ -40,6 +40,16 @@ def stop_handler(event):
 gdb.events.stop.connect(stop_handler)
 
 
+def on_exit(event):
+    print(
+        f"Thank you for using ChatDBG!\nIf you've enjoyed your experience, feel free to share your success stories here: https://github.com/plasma-umass/ChatDBG/issues/53"
+    )
+
+
+# Register the exit event handler
+gdb.events.exited.connect(on_exit)
+
+
 class Code(gdb.Command):
 
     def __init__(self):

--- a/src/chatdbg/chatdbg_lldb.py
+++ b/src/chatdbg/chatdbg_lldb.py
@@ -78,6 +78,11 @@ class LLDBDialog(DBGDialog):
         super().__init__(prompt)
         self._debugger = debugger
 
+    def _exit_message(self):
+        print(
+            f"Thank you for using ChatDBG!\nIf you've enjoyed your experience, feel free to share your success stories here: https://github.com/plasma-umass/ChatDBG/issues/53"
+        )
+
     def _message_is_a_bad_command_error(self, message):
         return message.strip().endswith("is not a valid command.")
 

--- a/src/chatdbg/chatdbg_lldb.py
+++ b/src/chatdbg/chatdbg_lldb.py
@@ -13,7 +13,7 @@ from chatdbg.native_util.stacks import (
     _SkippedFramesEntry,
 )
 from chatdbg.util.config import chatdbg_config
-from chatdbg.util.exit_message import print_exit_message
+from chatdbg.util.exit_message import chatdbg_was_called, print_exit_message
 from chatdbg.native_util.safety import command_is_safe
 
 
@@ -79,10 +79,8 @@ class LLDBDialog(DBGDialog):
 
     def __init__(self, prompt, debugger) -> None:
         super().__init__(prompt)
+        chatdbg_was_called()
         self._debugger = debugger
-
-    def dialog(self, user_text):
-        super().dialog(user_text)
 
     def _message_is_a_bad_command_error(self, message):
         return message.strip().endswith("is not a valid command.")

--- a/src/chatdbg/chatdbg_lldb.py
+++ b/src/chatdbg/chatdbg_lldb.py
@@ -13,6 +13,7 @@ from chatdbg.native_util.stacks import (
     _SkippedFramesEntry,
 )
 from chatdbg.util.config import chatdbg_config
+from chatdbg.util.exit_message import print_exit_message
 from chatdbg.native_util.safety import command_is_safe
 
 # The file produced by the panic handler if the Rust program is using the chatdbg crate.
@@ -78,10 +79,9 @@ class LLDBDialog(DBGDialog):
         super().__init__(prompt)
         self._debugger = debugger
 
-    def _exit_message(self):
-        print(
-            f"Thank you for using ChatDBG!\nIf you've enjoyed your experience, feel free to share your success stories here: https://github.com/plasma-umass/ChatDBG/issues/53"
-        )
+    def dialog(self, user_text):
+        super().dialog(user_text)
+        print_exit_message()
 
     def _message_is_a_bad_command_error(self, message):
         return message.strip().endswith("is not a valid command.")

--- a/src/chatdbg/chatdbg_lldb.py
+++ b/src/chatdbg/chatdbg_lldb.py
@@ -16,6 +16,7 @@ from chatdbg.util.config import chatdbg_config
 from chatdbg.util.exit_message import print_exit_message
 from chatdbg.native_util.safety import command_is_safe
 
+
 # The file produced by the panic handler if the Rust program is using the chatdbg crate.
 RUST_PANIC_LOG_FILENAME = "panic_log.txt"
 PROMPT = "(ChatDBG lldb) "
@@ -23,6 +24,7 @@ PROMPT = "(ChatDBG lldb) "
 
 def __lldb_init_module(debugger: lldb.SBDebugger, internal_dict: dict) -> None:
     debugger.HandleCommand(f"settings set prompt '{PROMPT}'")
+    debugger.SetDestroyCallback(print_exit_message)
     chatdbg_config.format = "md"
 
 
@@ -81,7 +83,6 @@ class LLDBDialog(DBGDialog):
 
     def dialog(self, user_text):
         super().dialog(user_text)
-        print_exit_message()
 
     def _message_is_a_bad_command_error(self, message):
         return message.strip().endswith("is not a valid command.")

--- a/src/chatdbg/chatdbg_pdb.py
+++ b/src/chatdbg/chatdbg_pdb.py
@@ -79,6 +79,11 @@ class ChatDBG(ChatDBGSuper):
         self._text_width = 120
         self._assistant = None
         atexit.register(lambda: self._close_assistant())
+        atexit.register(
+            lambda: print(
+                f"Thank you for using ChatDBG!\nIf you've enjoyed your experience, feel free to share your success stories here: https://github.com/plasma-umass/ChatDBG/issues/53"
+            )
+        )
 
         self._history = CommandHistory(self.prompt)
         self._error_message = ""
@@ -287,7 +292,7 @@ class ChatDBG(ChatDBGSuper):
         try:
             if chatdbg_config.unsafe:
                 return super._getval(arg)
-            else:   
+            else:
                 return sandbox_eval(arg, self.curframe.f_globals, self.curframe_locals)
         except NameError as e:
             self.error(f"NameError: {e}")

--- a/src/chatdbg/chatdbg_pdb.py
+++ b/src/chatdbg/chatdbg_pdb.py
@@ -29,7 +29,7 @@ from chatdbg.util.text import strip_ansi, truncate_proportionally
 from chatdbg.util.config import chatdbg_config
 from chatdbg.util.log import ChatDBGLog
 from chatdbg.util.history import CommandHistory
-from chatdbg.util.exit_message import print_exit_message
+from chatdbg.util.exit_message import chatdbg_was_called, print_exit_message
 
 
 def load_ipython_extension(ipython):
@@ -79,8 +79,8 @@ class ChatDBG(ChatDBGSuper):
         self._chat_prefix = "   "
         self._text_width = 120
         self._assistant = None
-        atexit.register(lambda: self._close_assistant())
         atexit.register(print_exit_message)
+        atexit.register(lambda: self._close_assistant())
 
         self._history = CommandHistory(self.prompt)
         self._error_message = ""
@@ -578,6 +578,7 @@ class ChatDBG(ChatDBGSuper):
         """chat
         Send a chat message.
         """
+        chatdbg_was_called()
         self.was_chat_or_renew = True
 
         full_prompt = self._build_prompt(arg, self._assistant != None)

--- a/src/chatdbg/chatdbg_pdb.py
+++ b/src/chatdbg/chatdbg_pdb.py
@@ -29,6 +29,7 @@ from chatdbg.util.text import strip_ansi, truncate_proportionally
 from chatdbg.util.config import chatdbg_config
 from chatdbg.util.log import ChatDBGLog
 from chatdbg.util.history import CommandHistory
+from chatdbg.util.exit_message import print_exit_message
 
 
 def load_ipython_extension(ipython):
@@ -79,11 +80,7 @@ class ChatDBG(ChatDBGSuper):
         self._text_width = 120
         self._assistant = None
         atexit.register(lambda: self._close_assistant())
-        atexit.register(
-            lambda: print(
-                f"Thank you for using ChatDBG!\nIf you've enjoyed your experience, feel free to share your success stories here: https://github.com/plasma-umass/ChatDBG/issues/53"
-            )
-        )
+        atexit.register(print_exit_message)
 
         self._history = CommandHistory(self.prompt)
         self._error_message = ""

--- a/src/chatdbg/native_util/dbg_dialog.py
+++ b/src/chatdbg/native_util/dbg_dialog.py
@@ -74,6 +74,11 @@ class DBGDialog:
                 break
 
         assistant.close()
+        # Only implemented in LLDB
+        self._exit_message()
+
+    def _exit_message(self):
+        pass
 
     # Return string for valid command.  None if the command is not valid.
     def _run_one_command(self, command):

--- a/src/chatdbg/native_util/dbg_dialog.py
+++ b/src/chatdbg/native_util/dbg_dialog.py
@@ -74,11 +74,6 @@ class DBGDialog:
                 break
 
         assistant.close()
-        # Only implemented in LLDB
-        self._exit_message()
-
-    def _exit_message(self):
-        pass
 
     # Return string for valid command.  None if the command is not valid.
     def _run_one_command(self, command):

--- a/src/chatdbg/util/exit_message.py
+++ b/src/chatdbg/util/exit_message.py
@@ -1,3 +1,3 @@
-def print_exit_message(event=None) -> str:
+def print_exit_message(*args: Any, **kwargs: Any) -> None:
     print("Thank you for using ChatDBG!")
     print("Share your success stories here: github.com/plasma-umass/ChatDBG/issues/53")

--- a/src/chatdbg/util/exit_message.py
+++ b/src/chatdbg/util/exit_message.py
@@ -1,6 +1,17 @@
 from typing import Any
 
+_chatdbg_was_called = False
+
+
+def chatdbg_was_called() -> None:
+    global _chatdbg_was_called
+    _chatdbg_was_called = True
+
 
 def print_exit_message(*args: Any, **kwargs: Any) -> None:
-    print("Thank you for using ChatDBG!")
-    print("Share your success stories here: github.com/plasma-umass/ChatDBG/issues/53")
+    global _chatdbg_was_called
+    if _chatdbg_was_called:
+        print("Thank you for using ChatDBG!")
+        print(
+            "Share your success stories here: github.com/plasma-umass/ChatDBG/issues/53"
+        )

--- a/src/chatdbg/util/exit_message.py
+++ b/src/chatdbg/util/exit_message.py
@@ -1,0 +1,3 @@
+def print_exit_message(event=None) -> str:
+    print("Thank you for using ChatDBG!")
+    print("Share your success stories here: github.com/plasma-umass/ChatDBG/issues/53")

--- a/src/chatdbg/util/exit_message.py
+++ b/src/chatdbg/util/exit_message.py
@@ -1,3 +1,6 @@
+from typing import Any
+
+
 def print_exit_message(*args: Any, **kwargs: Any) -> None:
     print("Thank you for using ChatDBG!")
     print("Share your success stories here: github.com/plasma-umass/ChatDBG/issues/53")


### PR DESCRIPTION
Added exit msgs with link to success stories page.
GDB/PDB: Msg prints when GDB/PDB is quit, returning to CLI.
LLDB: Doesn't have an on-exit event, so prints every time ChatDBG is exited and returns to LLDB interface. Maybe should just remove entirely?