### PR TITLE
fix to tool_call crash

### DIFF
--- a/src/chatdbg/assistant/assistant.py
+++ b/src/chatdbg/assistant/assistant.py
@@ -271,6 +271,9 @@ class Assistant:
             # has only tool calls, and skip this step
             response_message = completion.choices[0].message
             if response_message.content != None:
+                # fix: remove tool calls.  They get added below.
+                response_message = response_message.copy()
+                response_message["tool_calls"] = None                
                 self._conversation.append(response_message.json())
 
             if response_message.content != None:


### PR DESCRIPTION
Caused by an upgrade to litellm and openai packages -- they are more stringent on the tool call messages that appear in the message history for completions.
