### PR TITLE
Use complete URL to enable clicking in terminal

### DIFF
--- a/src/chatdbg/util/exit_message.py
+++ b/src/chatdbg/util/exit_message.py
@@ -13,5 +13,5 @@ def print_exit_message(*args: Any, **kwargs: Any) -> None:
     if _chatdbg_was_called:
         print("Thank you for using ChatDBG!")
         print(
-            "Share your success stories here: github.com/plasma-umass/ChatDBG/issues/53"
+            "Share your success stories here: https://github.com/plasma-umass/ChatDBG/issues/53"
         )


### PR DESCRIPTION
At least in my terminal, links need to have their protocol to be clickable, which is nicer than needing to copy and paste.