### PR TITLE
Feat/50 catch unspecified args

### DIFF
--- a/src/chatdbg/__main__.py
+++ b/src/chatdbg/__main__.py
@@ -23,6 +23,7 @@ def main() -> None:
     except GetoptError as e:
         print(f"Unrecognized option: {e.opt}\n")
         print_help()
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/src/chatdbg/__main__.py
+++ b/src/chatdbg/__main__.py
@@ -1,4 +1,5 @@
 import sys
+from getopt import GetoptError
 
 import ipdb
 
@@ -17,7 +18,11 @@ def main() -> None:
 
     sys.argv = [sys.argv[0]] + args
 
-    ipdb.__main__.main()
+    try:
+        ipdb.__main__.main()
+    except GetoptError as e:
+        print(f"Unrecognized option: {e.opt}\n")
+        print_help()
 
 
 if __name__ == "__main__":

--- a/src/chatdbg/__main__.py
+++ b/src/chatdbg/__main__.py
@@ -1,25 +1,10 @@
-import ipdb
-from chatdbg.chatdbg_pdb import ChatDBG
-from chatdbg.util.config import chatdbg_config
 import sys
 
-_usage = """\
-usage: python -m ipdb [-m] [-c command] ... pyfile [arg] ...
+import ipdb
 
-Debug the Python program given by pyfile.
-
-Initial commands are read from .pdbrc files in your home directory
-and in the current directory, if they exist.  Commands supplied with
--c are executed after commands from .pdbrc files.
-
-To let the script run until an exception occurs, use "-c continue".
-To let the script run up to a given line X in the debugged file, use
-"-c 'until X'"
-
-Option -m is available only in Python 3.7 and later.
-
-ChatDBG-specific options may appear anywhere before pyfile:
-"""
+from chatdbg.chatdbg_pdb import ChatDBG
+from chatdbg.util.config import chatdbg_config
+from chatdbg.util.help import print_help
 
 
 def main() -> None:
@@ -28,9 +13,7 @@ def main() -> None:
     args = chatdbg_config.parse_user_flags(sys.argv[1:])
 
     if "-h" in args or "--help" in args:
-        print(_usage)
-        print(chatdbg_config.user_flags_help())
-        sys.exit()
+        print_help()
 
     sys.argv = [sys.argv[0]] + args
 

--- a/src/chatdbg/util/help.py
+++ b/src/chatdbg/util/help.py
@@ -1,0 +1,27 @@
+import sys
+
+from chatdbg.util.config import chatdbg_config
+
+_usage = """\
+usage: python -m ipdb [-m] [-c command] ... pyfile [arg] ...
+
+Debug the Python program given by pyfile.
+
+Initial commands are read from .pdbrc files in your home directory
+and in the current directory, if they exist.  Commands supplied with
+-c are executed after commands from .pdbrc files.
+
+To let the script run until an exception occurs, use "-c continue".
+To let the script run up to a given line X in the debugged file, use
+"-c 'until X'"
+
+Option -m is available only in Python 3.7 and later.
+
+ChatDBG-specific options may appear anywhere before pyfile:
+"""
+
+
+def print_help():
+    print(_usage)
+    print(chatdbg_config.user_flags_help())
+    sys.exit()


### PR DESCRIPTION
## Description
Gracefully handle unexpected options by displaying help message. Implements #50. 

## How to test
1) Check that ChatDBG still works normally by debugging a sample script.
2) Check that passing an unknown option like `-v` does not cause an error, but rather prints the help message.

