### PR TITLE
resolves #68

### DIFF
--- a/src/chatdbg/assistant/assistant.py
+++ b/src/chatdbg/assistant/assistant.py
@@ -204,7 +204,7 @@ class Assistant:
                 tool_chunks = []
                 for chunk in stream:
                     chunks.append(chunk)
-                    if chunk.choices[0].delta.content != None:
+                    if chunk.choices[0].delta.content:
                         self._broadcast(
                             "on_stream_delta", chunk.choices[0].delta.content
                         )


### PR DESCRIPTION
Gemini can return tool-related chunks where `delta.content` is the empty string instead of `None`. The previous condition
`chunk.choices[0].delta.content != None` caused these chunks to be discarded, breaking tool processing for Gemini models.

This change updates the condition to check for a truthy value, ensuring that chunks with either `None` or the empty string are routed to the tool-handling logic.