### PR TITLE
Lower Python requirement to >=3.9 and verify install in conda+docker …

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
 ]
 description = "AI-assisted debugging. Uses AI to answer 'why'."
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 classifiers = [
   "Programming Language :: Python :: 3",
   "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
…(#66)

- Lowered minimum Python requirement in `pyproject.toml` from 3.10 → 3.9
- Verified editable install and import under:
  • Conda environment (Python 3.9) - `pip install -e .` succeeded; `import chatdbg` works
  • Docker `python:3.9` image (GDB uses Python 3.13) - added `/work/src` to `sys.path` for import
- Confirmed `why` executes without `old_stuff.chatdbg_utils` AttributeError
